### PR TITLE
#28 modify item code.

### DIFF
--- a/docs/api/pos-service-api.yaml
+++ b/docs/api/pos-service-api.yaml
@@ -274,7 +274,7 @@ components:
       properties:
         itemCode:
           type: string
-          example: "4901520113903"
+          example: "4901427401646"
         quantity:
           type: integer
           format: int32
@@ -376,7 +376,7 @@ components:
           example: 1
         itemCode:
           type: string
-          example: "49000000000009"
+          example: "4901427401646"
         itemName:
           type: string
           example: テスト商品


### PR DESCRIPTION
POS API 動作確認時の商品コードが存在しないコードであったため、
fudepen のコードに変える手間がありました。
手間を減らすため、YAML 定義に記載のコードを fudepen のコードに修正しました。
お手数ですが、ご確認のほどよろしくお願いします。