### PR TITLE
Fixed serverfarm's properties on ARM templates

### DIFF
--- a/src/arm-template/box-service-template.json
+++ b/src/arm-template/box-service-template.json
@@ -190,7 +190,9 @@
       "sku": {
         "name": "[parameters('boxApiAppServicePlanSku')]"
       },
-      "properties": {}
+      "properties": {
+        "numberOfWorkers": 1
+      }
     },
     {
       "name": "[variables('boxApiStorageAccountsName')]",

--- a/src/arm-template/item-service-template.json
+++ b/src/arm-template/item-service-template.json
@@ -109,7 +109,9 @@
       "sku": {
         "name": "[parameters('itemServiceAppServicePlanSkuName')]"
       },
-      "properties": {}
+      "properties": {
+        "numberOfWorkers": 1
+      }
     },
     {
       "comments": "item-master-api",

--- a/src/arm-template/minimal/common-template.json
+++ b/src/arm-template/minimal/common-template.json
@@ -80,7 +80,9 @@
       "sku": {
         "name": "[parameters('appServicePlanSkuName')]"
       },
-      "properties": {}
+      "properties": {
+        "numberOfWorkers": 1
+      }
     }
   ],
   "outputs": {

--- a/src/arm-template/pos-service-template.json
+++ b/src/arm-template/pos-service-template.json
@@ -188,7 +188,9 @@
       "sku": {
         "name": "[parameters('posApiAppServicePlanSku')]"
       },
-      "properties": {}
+      "properties": {
+        "numberOfWorkers": 1
+      }
     },
     {
       "name": "[variables('posApiStorageAccountsName')]",

--- a/src/arm-template/stock-service-template.json
+++ b/src/arm-template/stock-service-template.json
@@ -272,7 +272,9 @@
       "sku": {
         "name": "[parameters('stockServiceAppServicePlanSkuName')]"
       },
-      "properties": {}
+      "properties": {
+        "numberOfWorkers": 1
+      }
     },
     {
       "comments": "stock-command-api",


### PR DESCRIPTION
Azure Service Plan のデプロイに失敗する不具合を修正しました。
masterブランチマージ前に、この更新後のテンプレートを使ってデプロイするには、下記のようにテンプレートの参考先を変更してご確認ください。

```
$TEMPLATE_URL="https://raw.githubusercontent.com/intelligent-retail/smart-store/fix-arm-template-for-serverfarm/src/arm-template"
```